### PR TITLE
Replace twig-cs-filter format parameter with report

### DIFF
--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -64,7 +64,7 @@ tasks:
         DIRS_ARR=({{.TWIG_DIRS}})
         for DIR in "${DIRS_ARR[@]}"; do
           if [ "{{.format}}" == "junit" ]; then
-            ./vendor/bin/twig-cs-fixer lint $DIR --format junit
+            ./vendor/bin/twig-cs-fixer lint $DIR --report junit
           else
             ./vendor/bin/twig-cs-fixer lint $DIR
           fi


### PR DESCRIPTION
Running `test:lint` task we are getting the following error:

```
[test:lint]   The "--format" option does not exist.  
[test:lint]                                          
[test:lint] 
[test:lint] lint [-l|--level LEVEL] [-c|--config CONFIG] [-r|--report REPORT] [-f|--fix] [--no-cache] [--debug] [--] [<paths>...]
```
This error is thrown by the `twig-cs-fixer` invocation in line 67.

According to the package [docs](https://github.com/VincentLanglet/Twig-CS-Fixer/blob/main/docs/command.md), the parameter used should be `--report` instead of `--format`