### PR TITLE
Add apk upgrade to Common.gitlab-ci.yml

### DIFF
--- a/scaffold/gitlab/Common.gitlab-ci.yml
+++ b/scaffold/gitlab/Common.gitlab-ci.yml
@@ -17,5 +17,6 @@
 
 .drainpipe_setup_node:
   script:
+    - apk upgrade
     - apk add --update nodejs npm
     - npm install -g yarn


### PR DESCRIPTION
In our Gitlab CI pipeline we are getting this error while node is being setup.

```
$ apk add --update nodejs npm
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
fetch https://dl-4.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
(1/5) Installing ada-libs (2.9.2-r1)
(2/5) Installing simdjson (3.10.1-r0)
(3/5) Installing simdutf (5.6.3-r0)
(4/5) Installing nodejs (22.13.1-r0)
(5/5) Installing npm (10.9.1-r0)
Executing busybox-1.37.0-r12.trigger
OK: 327 MiB in 200 packages
$ npm install -g yarn
Error relocating /usr/bin/node: sqlite3session_attach: symbol not found
Error relocating /usr/bin/node: sqlite3changeset_apply: symbol not found
Error relocating /usr/bin/node: sqlite3session_create: symbol not found
Error relocating /usr/bin/node: sqlite3session_changeset: symbol not found
Error relocating /usr/bin/node: sqlite3session_patchset: symbol not found
Error relocating /usr/bin/node: sqlite3session_delete: symbol not found
```

To mitigate it, we added the following step at the beginning of the process:
`apk upgrade`

Creating this PR to check if this could be considered to be integrated in the main drainpipe process.
